### PR TITLE
Sam/lineage 18.1

### DIFF
--- a/sepolicy/vendor/hal_sensors_default.te
+++ b/sepolicy/vendor/hal_sensors_default.te
@@ -1,0 +1,1 @@
+allow hal_sensors_default sysfs_leds:file r_file_perms;


### PR DESCRIPTION
Fix issue where seLinux prevented `hal_sensors_default` from accessing backlight brightness.